### PR TITLE
Update FAQ page and data fetching logic

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,6 +1,9 @@
 import FaqPage  from '@/components/templates/FaqPage';
 import { getFaqData } from '@/server/actions/footer';
 
+export const revalidate = 3600; // 1 hour
+export const dynamic = 'force-static';
+
 export default async function Page() {
   const res = await getFaqData();
   const faqData = res || []

--- a/src/server/actions/footer.ts
+++ b/src/server/actions/footer.ts
@@ -17,7 +17,7 @@ export const getPrivacyData = async () => {
 
 export const getFaqData = async () => {
   try {
-    const URL = API_BASE_URL + API_ENPOINTS.FAQ + '?sort[0]=sortOrder:asc';
+    const URL = API_BASE_URL + API_ENPOINTS.FAQ + '?sort[0]=sortOrder:asc&pagination[page]=1&pagination[pageSize]=100';
     const { data } = await getRequest({ API: URL });
     return sanitizeStrapiData(data?.data, true);
   } catch (e) {


### PR DESCRIPTION
- Set revalidation time to 1 hour and enforce static rendering for the FAQ page.
- Modify the FAQ data fetching URL to include pagination parameters for improved data retrieval.